### PR TITLE
Made offline people return a times symbol (x) instead of a gendered symbol

### DIFF
--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -60,25 +60,29 @@
     }
   }
 
-  export function getGenderIcon(gender: Character.Gender): string {
-    switch (gender) {
-      case 'None':
-        return 'fa fa-genderless';
-      case 'Male':
-        return 'fa fa-mars';
-      case 'Female':
-        return 'fa fa-venus';
-      case 'Shemale':
-        return 'fa fa-mercury';
-      case 'Herm':
-        return 'fa fa-transgender';
-      case 'Male-Herm':
-        return 'fa fa-mars-stroke-v';
-      case 'Cunt-boy':
-        return 'fa fa-mars-stroke-h';
-      case 'Transgender':
-        return 'fa fa-transgender-alt';
+  export function getGenderIcon(gender: Character.Gender, status: Character.Status): string {
+    if (status !== 'offline') {
+      switch (gender) {
+        case 'None':
+          return 'fa fa-genderless';
+        case 'Male':
+          return 'fa fa-mars';
+        case 'Female':
+          return 'fa fa-venus';
+        case 'Shemale':
+          return 'fa fa-mercury';
+        case 'Herm':
+          return 'fa fa-transgender';
+        case 'Male-Herm':
+          return 'fa fa-mars-stroke-v';
+        case 'Cunt-boy':
+          return 'fa fa-mars-stroke-h';
+        case 'Transgender':
+          return 'fa fa-transgender-alt';
+      }
     }
+
+    return 'fa fa-times';
   }
 
   export interface StatusClasses {
@@ -161,7 +165,7 @@
       core.state.settings.horizonShowGenderMarker &&
       character.gender
     ) {
-      genderClass = `fa ${getGenderIcon(character.gender)}`;
+      genderClass = `fa ${getGenderIcon(character.gender, character.status)}`;
       //genderClass = 'fa fa-genderless' + ` gender-${gender}`;
     }
 


### PR DESCRIPTION
Realised it marked everyone currently offline with the same icon as anyone without a gender, gave that a quick change so it is now more obvious that they haven't just removed their gender and instead are just offline.

It makes this change as people go online/offline so added bonus is that you can see when people are offline in rooms much quicker since name colours do not change by default.

Maybe should implement that as a change too, make offline people immediately go grey rather than keep their coloured name.